### PR TITLE
Checkout project files that shouldn't get versioned before packing them

### DIFF
--- a/pack.ps1
+++ b/pack.ps1
@@ -1,9 +1,12 @@
-$solutionFile = ".\Xerris.Templates.sln"
-
 dotnet tool restore
 
 dotnet gitversion /updateprojectfiles /output buildserver
 
+# Only the parent project gets packaged, so only the parent project should get versioned.
+# See https://github.com/xerris/Xerris.DotNet.Templates/issues/5
+git checkout .\src\Templates\**\*.csproj -v
+
+$solutionFile = ".\Xerris.Templates.sln"
 $artifactsDirectory = "artifacts"
 
 Remove-Item  $artifactsDirectory -Force -Recurse -ErrorAction Ignore -Verbose


### PR DESCRIPTION
This is a bit of a hack, it could cause legitimate changes to project files to be overwritten if there are uncommitted changes. But it should be good enough for now.

Resolves #5 